### PR TITLE
handle generated form lists without eof marker

### DIFF
--- a/src/pmod_pt.erl
+++ b/src/pmod_pt.erl
@@ -109,7 +109,9 @@ add_attributes([F|Fs], Attrs) ->
 add_new_funcs([{eof,_}|_]=Fs, NewFs) ->
     NewFs ++ Fs;
 add_new_funcs([F|Fs], Es) ->
-    [F|add_new_funcs(Fs, Es)].
+    [F|add_new_funcs(Fs, Es)];
+add_new_funcs([], NewFs) ->
+    NewFs.
 
 maybe_extend([], _, _) ->
     %% No 'extends' attribute.


### PR DESCRIPTION
This was needed to get erl_selenium working.
